### PR TITLE
feat: add logging by syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ There are separate lines of development under different licenses (pull requests 
 * `--ec2`: Load config settings from EC2 user data.
 * `--gce`: Load config settings from GCE user data.
 * `--log`: Log critical errors to the given file.
+* `--rsyslog`: Log to a given IP address' syslog via UDP on the default port '514'.
 * `--noidle`: Doesn't wait for system idle at any point.
 
 * `--healthcheckport`: HTTP Health check port (defaults to 8889). Set to 0 to disable. Returns 200 if the agent is running and communicating with the server, 503 otherwise.

--- a/internal/logging_filter.py
+++ b/internal/logging_filter.py
@@ -1,0 +1,17 @@
+"""A filter for our logging handler"""
+
+import logging
+
+class LoggingFilter(logging.Filter):
+    def __init__(self, location, agent_name):
+        self.location = location
+        self.agent_name = agent_name
+        self.test_id = ''
+    def filter(self, record):
+        record.location = self.location
+        record.agent_name = self.agent_name
+        record.test_id = self.test_id
+        return True
+    def set_test_id(self, test_id):
+        self.test_id = test_id
+

--- a/internal/traffic_shaping.py
+++ b/internal/traffic_shaping.py
@@ -563,9 +563,20 @@ class NetEm(object):
                     subprocess.call(['sudo', 'tc', 'qdisc', 'add', 'dev', self.interface,
                                      'ingress'])
                     subprocess.call(['sudo', 'tc', 'filter', 'add', 'dev', self.interface, 'parent',
-                                     'ffff:', 'protocol', 'ip', 'u32', 'match', 'u32', '0', '0',
+                                     'ffff:', 'protocol', 'ip', 'prio', '2', 'u32', 'match', 'u32', '0', '0',
                                      'flowid', '1:1', 'action', 'mirred', 'egress', 'redirect',
                                      'dev', 'ifb0'])
+                    subprocess.call(['sudo', 'tc', 'filter', 'add', 'dev', self.interface, 'parent',
+                                     'ffff:', 'protocol', 'ip', 'prio', '1',
+                                     'u32', 'match', 'ip', 'protocol', '17', '0xff',
+                                     'match', 'ip', 'dport', '514', '0xffff',
+                                     'flowid', '1:1', 'action', 'pass'])
+                    subprocess.call(['sudo', 'tc', 'filter', 'add', 'dev', self.interface, 'parent',
+                                     'ffff:', 'protocol', 'ip', 'prio', '1',
+                                     'u32', 'match', 'ip', 'protocol', '6', '0xff',
+                                     'match', 'ip', 'dport', '22', '0xffff',
+                                     'match', 'ip', 'sport', '22', '0xffff',
+                                     'flowid', '1:1', 'action', 'pass'])
                 # Turn off tcp offload acceleration on the interfaces
                 try:
                     subprocess.call(['sudo', 'ethtool', '-K', self.interface, 'tso', 'off', 'gso', 'off', 'gro', 'off'])

--- a/internal/traffic_shaping.py
+++ b/internal/traffic_shaping.py
@@ -566,17 +566,13 @@ class NetEm(object):
                                      'ffff:', 'protocol', 'ip', 'prio', '2', 'u32', 'match', 'u32', '0', '0',
                                      'flowid', '1:1', 'action', 'mirred', 'egress', 'redirect',
                                      'dev', 'ifb0'])
-                    subprocess.call(['sudo', 'tc', 'filter', 'add', 'dev', self.interface, 'parent',
-                                     'ffff:', 'protocol', 'ip', 'prio', '1',
-                                     'u32', 'match', 'ip', 'protocol', '17', '0xff',
-                                     'match', 'ip', 'dport', '514', '0xffff',
-                                     'flowid', '1:1', 'action', 'pass'])
-                    subprocess.call(['sudo', 'tc', 'filter', 'add', 'dev', self.interface, 'parent',
-                                     'ffff:', 'protocol', 'ip', 'prio', '1',
-                                     'u32', 'match', 'ip', 'protocol', '6', '0xff',
-                                     'match', 'ip', 'dport', '22', '0xffff',
-                                     'match', 'ip', 'sport', '22', '0xffff',
-                                     'flowid', '1:1', 'action', 'pass'])
+                    for interface in [self.interface, 'ifb0']:
+                        for port in ['22', '514']:
+                            for direction in ['dport', 'sport']:
+                                subprocess.call(['sudo', 'tc', 'filter', 'add', 'dev', interface, 'parent',
+                                                 'ffff:', 'protocol', 'ip', 'prio', '1',
+                                                 'u32', 'match', 'ip', direction, port, '0xffff',
+                                                 'flowid', '1:1', 'action', 'pass'])
                 # Turn off tcp offload acceleration on the interfaces
                 try:
                     subprocess.call(['sudo', 'ethtool', '-K', self.interface, 'tso', 'off', 'gso', 'off', 'gro', 'off'])


### PR DESCRIPTION
This change allows a user to opt into logging via syslog, in case they want the agent to open a socket out to a service that consumes logs.

WARNING - This likely does _not_ work on MacOS, since they changed the behavior of the syslog daemon