### PR TITLE
Change the source repo for Wappalyzer

### DIFF
--- a/update_wappalyzer.sh
+++ b/update_wappalyzer.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-git clone --depth 1 -b master https://github.com/wappalyzer/wappalyzer.git wappalyzer
+git clone --depth 1 -b master https://github.com/HTTPArchive/wappalyzer.git wappalyzer
 rm internal/support/Wappalyzer/technologies/*.json
 rm internal/support/Wappalyzer/*.json
 rm internal/support/Wappalyzer/wappalyzer.js


### PR DESCRIPTION
This changes the source repository for the update_wappalyzer.sh shell script to use (doesn't do anything with the actual wappalyzer detections).

The change is needed because Wappalyzer went private so the HTTP Archive is maintaining a fork.

A future change will remove the wappalyzer detection code from being embedded with wptagent and will make it a runtime option.