### PR TITLE
Logging fixes

### DIFF
--- a/ubuntu_install.sh
+++ b/ubuntu_install.sh
@@ -29,7 +29,7 @@ sudo dbus-uuidgen --ensure
 sudo fc-cache -f -v
 
 # Install the python modules
-until sudo pip3 install dnspython monotonic pillow psutil requests tornado wsaccel brotli fonttools selenium future usbmuxwrapper
+until sudo pip3 install dnspython monotonic pillow psutil requests tornado wsaccel brotli fonttools selenium future usbmuxwrapper pytz tzlocal
 do
     sleep 1
 done

--- a/wptagent.py
+++ b/wptagent.py
@@ -489,6 +489,7 @@ class WPTAgent(object):
 
         # Optional imports
         self.requires('fontTools', 'fonttools')
+        self.requires('pytz')
         self.requires('tzlocal')
 
         # Try patching ws4py with a faster lib

--- a/wptagent.py
+++ b/wptagent.py
@@ -8,7 +8,6 @@
 import atexit
 import logging
 import logging.handlers
-from internal.rfc5424logging import Rfc5424SysLogHandler, logging_context
 import os
 import platform
 import gzip
@@ -490,6 +489,7 @@ class WPTAgent(object):
 
         # Optional imports
         self.requires('fontTools', 'fonttools')
+        self.requires('tzlocal')
 
         # Try patching ws4py with a faster lib
         try:
@@ -1091,6 +1091,7 @@ def setup_logging(verbosity=0, log_format=None, log_file=None):
             logging.getLogger().addHandler(err_log)
     else:
         if log_format == "syslog" and log_file is not None:
+            from internal.rfc5424logging import Rfc5424SysLogHandler, logging_context
             logger = logging.getLogger()
             logger.setLevel(basic_log_level)
             handler = Rfc5424SysLogHandler( \


### PR DESCRIPTION
This changes the rfc5424 logging to only be imported when that mode of logging is being used and also adds an (optional) requirement for the `tzlocal` module which is required by the rfc5424 logging code.

This way the agents that are already deployed should install the module if it's not already on the systems.

Without these changes, the agents are likely to stop working as soon as they update unless tzlocal is installed on them (not part of the default install script).