### PR TITLE
Fixed the lighthouse user agent string

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -874,7 +874,7 @@ class DevtoolsBrowser(object):
                 command.extend(['--screenEmulation.disabled'])
             if 'user_agent_string' in self.job:
                 sanitized_user_agent = re.sub(r'[^a-zA-Z0-9_\-.;:/()\[\] ]+', '', self.job['user_agent_string'])
-                command.append('--chrome-flags="--user-agent=\'{0}\'"'.format(sanitized_user_agent))
+                command.extend(['--emulatedUserAgent', "'" + sanitized_user_agent + "'"])
             if len(task['block']):
                 for pattern in task['block']:
                     pattern = "'" + pattern.replace("'", "'\\''") + "'"


### PR DESCRIPTION
This fixes the setting of the Lighthouse user -agent string to use the newer command-line param. Otherwise it would default to overriding it with a mobile UA.