### PR TITLE
Add trusted mouseClick command to WPT

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -1360,28 +1360,28 @@ class DevTools(object):
                     self.send_character(char)
         except Exception:
             logging.exception('Error running type command')
-    def mouse_press(self, commandOptions):
+    def mouse_press(self, command_options):
         """Press down the mouse"""
         params = {
             'type': 'mousePressed',
-            'x': commandOptions['x'],
-            'y': commandOptions['y'],
-            'button': commandOptions['button'],
-            'clickCount': commandOptions['clickCount']
+            'x': command_options['x'],
+            'y': command_options['y'],
+            'button': command_options['button'],
+            'clickCount': command_options['clickCount']
         }
         self.send_command('Input.dispatchMouseEvent', params)
 
-    def mouse_release(self, commandOptions):
+    def mouse_release(self, command_options):
         """Let up the mouse"""
         self.send_command('Input.dispatchMouseEvent', {
             'type': 'mouseReleased',
-            'x': commandOptions['x'],
-            'y': commandOptions['y'],
-            'button': commandOptions['button'],
-            'clickCount': commandOptions['clickCount']
+            'x': command_options['x'],
+            'y': command_options['y'],
+            'button': command_options['button'],
+            'clickCount': command_options['clickCount']
         })
 
-    def mouseClick(self, params):
+    def mouse_click(self, params):
         """Simulate pressing the mouse"""
         try:
             self.mouse_press(params)

--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -1360,7 +1360,35 @@ class DevTools(object):
                     self.send_character(char)
         except Exception:
             logging.exception('Error running type command')
+    def mouse_press(self, commandOptions):
+        """Press down the mouse"""
+        params = {
+            'type': 'mousePressed',
+            'x': commandOptions['x'],
+            'y': commandOptions['y'],
+            'button': commandOptions['button'],
+            'clickCount': commandOptions['clickCount']
+        }
+        self.send_command('Input.dispatchMouseEvent', params)
 
+    def mouse_release(self, commandOptions):
+        """Let up the mouse"""
+        self.send_command('Input.dispatchMouseEvent', {
+            'type': 'mouseReleased',
+            'x': commandOptions['x'],
+            'y': commandOptions['y'],
+            'button': commandOptions['button'],
+            'clickCount': commandOptions['clickCount']
+        })
+
+    def mouseClick(self, params):
+        """Simulate pressing the mouse"""
+        try:
+            self.mouse_press(params)
+            self.mouse_release(params)
+        except Exception:
+            logging.exception('Error running mouse click command')
+            
     def enable_target(self, target_id=None):
         """Hook up the necessary network (or other) events for the given target"""
         try:

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -766,7 +766,7 @@ class DevtoolsBrowser(object):
             self.devtools.type_text(command['target'])
         elif command['command'] == 'keypress':
             self.devtools.keypress(command['target'])
-        elif command['command'] == 'mouseclick':
+        elif command['command'] == 'mouse_click':
             if 'target' in command:
                 target = command['target']
                 separator = target.find('=')
@@ -775,7 +775,6 @@ class DevtoolsBrowser(object):
                 if separator >= 0:
                     attribute = target[:separator]
                     attr_value = target[separator + 1:]
-                    mouseclickError = False
                     try:
                         query = "JSON.stringify(document.querySelector('[{0}=\"{1}\"]').getBoundingClientRect())".format(
                             attribute, attr_value)
@@ -791,21 +790,19 @@ class DevtoolsBrowser(object):
                             clickCount = 2                 
                         elif value is not None:
                             logging.info("Click type is not defined.")
-                            mouseclickError = True
 
                         if 'x' in resp_json and 'y' in resp_json and 'width' in resp_json and 'height' in resp_json:
                             x = int(float(resp_json['x'])) + int(float(resp_json['width']))/2
                             y = int(float(resp_json['y'])) + int(float(resp_json['height']))/2
-                            commandOptions = {}
-                            commandOptions['x'] = x
-                            commandOptions['y'] = y
-                            commandOptions['button'] = button
-                            commandOptions['clickCount'] = clickCount
-                            self.devtools.mouseClick(commandOptions)
+                            command_options = {}
+                            command_options['x'] = x
+                            command_options['y'] = y
+                            command_options['button'] = button
+                            command_options['clickCount'] = clickCount
+                            self.devtools.mouse_click(command_options)
                     except:
-                        self.task['error'] = 'Exception parsing mouseClick arguments.'
+                        self.task['error'] = 'Exception parsing mouse_click arguments.'
                         logging.error(self.task['error'])
-                        mouseclickError = True
         elif command['command'] == 'waitfor':
             try:
                 self.devtools.wait_for_script = command['target'] if command['target'] else None

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -766,7 +766,7 @@ class DevtoolsBrowser(object):
             self.devtools.type_text(command['target'])
         elif command['command'] == 'keypress':
             self.devtools.keypress(command['target'])
-        elif command['command'] == 'mouse_click':
+        elif command['command'] == 'mouseClick':
             if 'target' in command:
                 target = command['target']
                 separator = target.find('=')
@@ -801,7 +801,7 @@ class DevtoolsBrowser(object):
                             command_options['clickCount'] = clickCount
                             self.devtools.mouse_click(command_options)
                     except:
-                        self.task['error'] = 'Exception parsing mouse_click arguments.'
+                        self.task['error'] = 'Exception parsing mouseClick arguments.'
                         logging.error(self.task['error'])
         elif command['command'] == 'waitfor':
             try:


### PR DESCRIPTION
Existing **click** and **clickAndWait** **WPT** commands are JavaScript initiated events which are synthetic. Hence "Trusted" flag for JS events is set to false. Such events get ignored by EventTiming API (_https://www.w3.org/TR/event-timing/_). This problem was issued _https://github.com/catchpoint/WebPageTest/issues/3048_

<img width="645" alt="image" src="https://github.com/catchpoint/WebPageTest.agent/assets/162485864/90997027-4b8c-4564-a99b-3b40ca671ca4">



Moreover, **WPT** **click** command does not support **right** and **double** click; mentioned in _https://github.com/catchpoint/WebPageTest/issues/3049_ . 

We have created a new **mouseClick** command with the following format which supports left, right and double click:
**mouseClick** [tab] **Id| selector** [tab] **left|right|double**

The new command uses **Devtools Protocol** (https://chromedevtools.github.io/devtools-protocol/tot/Input/) input domain to dispatch **Trusted** mousepressed and mousereleased events.

<img width="864" alt="image" src="https://github.com/catchpoint/WebPageTest.agent/assets/162485864/3c41f954-52e1-40b8-80b9-cfe61b6abc75">



