### PR TITLE
Fix Firefox log parser

### DIFF
--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -982,10 +982,7 @@ class Firefox(DesktopBrowser):
                     parts = command['target'].split(',')
                     lat = float(parts[0])
                     lng = float(parts[1])
-                    location_uri = 'data:application/json,{{'\
-                        '"status":"OK","accuracy":{2:d},'\
-                        '"location":{{"lat":{0:f},"lng":{1:f}}}'\
-                        '}}'.format(lat, lng, accuracy)
+                    location_uri = _get_location_uri(accuracy, lat, lng)
                     logging.debug('Setting location: %s', location_uri)
                     self.set_pref('geo.wifi.uri', location_uri)
             except Exception:

--- a/internal/support/Firefox/profile/prefs.js
+++ b/internal/support/Firefox/profile/prefs.js
@@ -111,7 +111,6 @@ user_pref("security.warn_viewing_mixed", false);
 user_pref("security.warn_entering_secure", false);
 user_pref("security.warn_leaving_secure", false);
 user_pref("security.warn_submit_insecure", false);
-user_pref("security.OCSP.enabled", 0);
 user_pref("services.settings.server", "");
 user_pref("services.sync.migrated", true);
 user_pref("services.sync.engine.bookmarks", false);

--- a/internal/support/Firefox/profile/prefs.js
+++ b/internal/support/Firefox/profile/prefs.js
@@ -111,6 +111,7 @@ user_pref("security.warn_viewing_mixed", false);
 user_pref("security.warn_entering_secure", false);
 user_pref("security.warn_leaving_secure", false);
 user_pref("security.warn_submit_insecure", false);
+user_pref("security.OCSP.enabled", 0);
 user_pref("services.settings.server", "");
 user_pref("services.sync.migrated", true);
 user_pref("services.sync.engine.bookmarks", false);

--- a/wptagent.py
+++ b/wptagent.py
@@ -1084,7 +1084,7 @@ def fix_selenium_version():
     newer versions are going to use 4.8.3
     """
     from internal.os_util import run_elevated
-    version = '4.8.3'
+    version = '4.18.1'
     if sys.version_info[1] == 6:
         version = '3.141.0'
 


### PR DESCRIPTION
This fixes Firefox log parser and add support for latest selenium:

Before:
![image](https://github.com/user-attachments/assets/1cd64c94-b921-487e-8da9-c46817f77f55)


After:
![image](https://github.com/user-attachments/assets/e041eb9c-2e5f-432f-8472-dee48e8fdf46)
